### PR TITLE
Upgrade kubernetes.core  version for ocp-workloads

### DIFF
--- a/ansible/configs/ocp-workloads/requirements.yml
+++ b/ansible/configs/ocp-workloads/requirements.yml
@@ -7,4 +7,4 @@ roles:
 
 collections:
 - name: kubernetes.core
-  version: 1.2.0
+  version: 2.3.0


### PR DESCRIPTION
##### SUMMARY

An error is thrown when running a removal workload of a LPE_INTEGRATION DEV lab:
`FAILED! => {"reason": "couldn't resolve module/action 'kubernetes.core.k8s_json_patch'. This often indicates a misspelling, missing collection, or incorrect module path.\\n\\nThe error appears to be in '/tmp/awx_482900_wxz_7ck2/project/ansible/roles_ocp_workloads/ocp4_workload_lpe_fuse/tasks/remove_workload.yml': line 13, column 3,`
Upgrading kubernetes.core should resolve this

The LPE_INTEGRATION DEV lab was introduced in [4698](https://github.com/redhat-cop/agnosticd/pull/4698)

##### ISSUE TYPE
- New config Pull Request

##### COMPONENT NAME
ocp-workloads

